### PR TITLE
fix(gatsby-config): ga-tagid fixed issue fixed

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -57,14 +57,15 @@ module.exports = {
     {
       resolve: `gatsby-plugin-google-gtag`,
       options: {
-        trackingIds: ['G-HFZ8KMRXTW'],
+        trackingIds: ['G-9HMJ423VGZ'],
         gtagConfig: {
           anonymize_ip: true,
           cookie_expires: 0,
         },
         pluginConfig: {
-          head: false,
+          head: true,
           respectDNT: true, // Respect Do Not Track
+          delayOnRouteUpdate: 0,
         },
       },
     },


### PR DESCRIPTION
Issue: Fix GA on Landing page 
Fix: GA tag id was wrong on gatsby config file . changed it to the id available on the GA dashboard